### PR TITLE
Add ServerTimingUtility helpers for adding metrics

### DIFF
--- a/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
@@ -54,24 +54,11 @@ namespace Lib.AspNetCore.ServerTiming
         /// <param name="timing">The timings to extend</param>
         /// <param name="duration">The duration to log in ms.</param>
         /// <param name="metricName">The name of the metric to log.</param>
-        public static void AddMetric(this IServerTiming timing, decimal duration, string metricName)
-        {
-            if (timing == null)
-                return;
-
-            var metric = new ServerTimingMetric(metricName, duration);
-            timing.Metrics.Add(metric);
-        }
-
-        /// <summary>Add a metric for the current caller.
-        /// <para>This will generate a metric name of "{fileName}.{function}+{lineNumber}"</para>
-        /// <para>This uses caller compile-time attributes to avoid reflection costs.</para></summary>
-        /// <param name="timing">The timings to extend</param>
-        /// <param name="duration">The duration to log in ms.</param>
         /// <param name="functionName">Optional, populated compile-time with the name of the calling function</param>
         /// <param name="filePath">Optional, populated compile-time with the path to the calling file</param>
         /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file</param>
-        public static void AddMetricCaller(this IServerTiming timing, decimal duration,
+        public static void AddMetric(this IServerTiming timing, decimal duration,
+            string metricName = null,
             [CallerMemberName] string functionName = null,
             [CallerFilePath] string filePath = null,
             [CallerLineNumber] int lineNumber = 0)
@@ -79,8 +66,8 @@ namespace Lib.AspNetCore.ServerTiming
             if (timing == null)
                 return;
 
-            string caller = FormatCallerName(functionName, filePath, lineNumber);
-            timing.AddMetric(duration, caller);
+            var metric = new ServerTimingMetric(metricName ?? FormatCallerName(functionName, filePath, lineNumber), duration);
+            timing.Metrics.Add(metric);
         }
 
         /// <summary>Format a metric name from caller params.</summary>

--- a/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
@@ -23,8 +23,10 @@ namespace Lib.AspNetCore.ServerTiming
             [CallerFilePath] string filePath = null,
             [CallerLineNumber] int lineNumber = 0)
         {
-            if (timing == null)
+            if (timing == null) 
+            {
                 return null;
+            }
 
             string caller = metricName ?? FormatCallerName(functionName, filePath, lineNumber);
             return new ServerTimingInstance(timing, caller);
@@ -46,8 +48,10 @@ namespace Lib.AspNetCore.ServerTiming
             [CallerFilePath] string filePath = null,
             [CallerLineNumber] int lineNumber = 0)
         {
-            using (timing.TimeAction(metricName, functionName, filePath, lineNumber))
+            using (timing.TimeAction(metricName, functionName, filePath, lineNumber)) 
+            {
                 return await task;
+            }
         }
 
         /// <summary>Add a metric to the timing, if present.</summary>
@@ -64,7 +68,9 @@ namespace Lib.AspNetCore.ServerTiming
             [CallerLineNumber] int lineNumber = 0)
         {
             if (timing == null)
+            {
                 return;
+            }
 
             var metric = new ServerTimingMetric(metricName ?? FormatCallerName(functionName, filePath, lineNumber), duration);
             timing.Metrics.Add(metric);
@@ -72,28 +78,28 @@ namespace Lib.AspNetCore.ServerTiming
 
         /// <summary>Format a metric name from caller params.</summary>
         /// <returns>Generated metric name of "{fileName}.{function}+{lineNumber}</returns>
-        static string FormatCallerName(string functionName, string filePath, int lineNumber) =>
+        private static string FormatCallerName(string functionName, string filePath, int lineNumber) =>
             string.Concat(Path.GetFileNameWithoutExtension(filePath), ".", functionName, "+", lineNumber);
 
         /// <summary>On dispose log the duration to the timing.</summary>
-        sealed class ServerTimingInstance : IDisposable
+        private sealed class ServerTimingInstance : IDisposable
         {
-            readonly IServerTiming timing;
-            readonly string metricName;
-            readonly Stopwatch watch;
+            private readonly IServerTiming _timing;
+            private readonly string _metricName;
+            private readonly Stopwatch _watch;
 
             public ServerTimingInstance(IServerTiming timing, string metricName)
             {
-                this.timing = timing;
-                this.metricName = metricName;
-                this.watch = new Stopwatch();
-                this.watch.Start();
+                _timing = timing;
+                _metricName = metricName;
+                _watch = new Stopwatch();
+                _watch.Start();
             }
 
-            void IDisposable.Dispose()
+            private void IDisposable.Dispose()
             {
-                this.watch.Stop();
-                this.timing.AddMetric(this.watch.ElapsedMilliseconds, this.metricName);
+                _watch.Stop();
+                _timing.AddMetric(_watch.ElapsedMilliseconds, _metricName);
             }
         }
     }

--- a/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
@@ -1,0 +1,113 @@
+namespace Lib.AspNetCore.ServerTiming 
+{
+    using Lib.AspNetCore.ServerTiming.Http.Headers;
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Runtime.CompilerServices;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+
+    /// <summary>Utilities for easier logging of timings.</summary>
+    static class ServerTimingUtility
+    {
+        /// <summary>Time the content of a using block.</summary>
+        /// <param name="timing">The logger to write to.</param>
+        /// <param name="metricName">Optional, metric name, if passed will override any called name.</param>
+        /// <param name="functionName">Optional, populated compile-time with the name of the calling function</param>
+        /// <param name="filePath">Optional, populated compile-time with the path to the calling file</param>
+        /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file</param>
+        public static IDisposable TimeAction(this IServerTiming timing,
+            string metricName = null,
+            [CallerMemberName] string functionName = null,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            if (timing == null)
+                return null;
+
+            string caller = metricName ?? FormatCallerName(functionName, filePath, lineNumber);
+            return new ServerTimingInstance(timing, caller);
+        }
+
+        /// <summary>Time an async task.</summary>
+        /// <typeparam name="T">Type of the tasl</typeparam>
+        /// <param name="task">The task to time</param>
+        /// <param name="timing">The logger to write to.</param>
+        /// <param name="metricName">Optional, metric name, if passed will override any called name.</param>
+        /// <param name="functionName">Optional, populated compile-time with the name of the calling function</param>
+        /// <param name="filePath">Optional, populated compile-time with the path to the calling file</param>
+        /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file</param>
+        /// <returns></returns>
+        public static async Task<T> TimeTask<T>(this IServerTiming timing,
+            Task<T> task,
+            string metricName = null,
+            [CallerMemberName] string functionName = null,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            using (timing.TimeAction(metricName, functionName, filePath, lineNumber))
+                return await task;
+        }
+
+        /// <summary>Add a metric to the timing, if present.</summary>
+        /// <param name="timing">The timings to extend</param>
+        /// <param name="duration">The duration to log in ms.</param>
+        /// <param name="metricName">The name of the metric to log.</param>
+        public static void AddMetric(this IServerTiming timing, decimal duration, string metricName)
+        {
+            if (timing == null)
+                return;
+
+            var metric = new ServerTimingMetric(metricName, duration);
+            timing.Metrics.Add(metric);
+        }
+
+        /// <summary>Add a metric for the current caller.
+        /// <para>This will generate a metric name of "{fileName}.{function}+{lineNumber}"</para>
+        /// <para>This uses caller compile-time attributes to avoid reflection costs.</para></summary>
+        /// <param name="timing">The timings to extend</param>
+        /// <param name="duration">The duration to log in ms.</param>
+        /// <param name="functionName">Optional, populated compile-time with the name of the calling function</param>
+        /// <param name="filePath">Optional, populated compile-time with the path to the calling file</param>
+        /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file</param>
+        public static void AddMetricCaller(this IServerTiming timing, decimal duration,
+            [CallerMemberName] string functionName = null,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            if (timing == null)
+                return;
+
+            string caller = FormatCallerName(functionName, filePath, lineNumber);
+            timing.AddMetric(duration, caller);
+        }
+
+        /// <summary>Format a metric name from caller params.</summary>
+        /// <returns>Generated metric name of "{fileName}.{function}+{lineNumber}</returns>
+        static string FormatCallerName(string functionName, string filePath, int lineNumber) =>
+            string.Concat(Path.GetFileNameWithoutExtension(filePath), ".", functionName, "+", lineNumber);
+
+        /// <summary>On dispose log the duration to the timing.</summary>
+        sealed class ServerTimingInstance : IDisposable
+        {
+            readonly IServerTiming timing;
+            readonly string metricName;
+            readonly Stopwatch watch;
+
+            public ServerTimingInstance(IServerTiming timing, string metricName)
+            {
+                this.timing = timing;
+                this.metricName = metricName;
+                this.watch = new Stopwatch();
+                this.watch.Start();
+            }
+
+            void IDisposable.Dispose()
+            {
+                this.watch.Stop();
+                this.timing.AddMetric(this.watch.ElapsedMilliseconds, this.metricName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds two extension methods that apply a using block to create a new metric over the duration of the block.

`TimeAction` takes advantage of how .NET handles `using` blocks. It creates an `IDisposable`, and when that is disposed it creates a new metric with the duration of the action:

```c#
IServerTiming timing = // Get from DI, for instance with [FromServices]

using (timing.TimeAction())
{
    // Do the thing you want to time
}
```

`TimeTask` wraps an `async` task to do the same thing:

```c#
// Before
var x = await SlowCallYouWantToTime();

// After
var x = await timing.TimeTask(SlowCallYouWantToTime());
```

Both actions create a metric called `{fileNameWithoutExtension}.{functionName}+{lineNumber}` by default. These use [caller information attributes](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/caller-information) to get values at compile time and so don't have a reflection overhead.

You can also provide your own metric name:

```c#
using (timing.TimeAction("metric-name-1"))
{
    // Do the thing you want to time
}

var x = await timing.TimeTask(SlowCallYouWantToTime(), "metric-name-2");
```

Finally, both `TimeAction` and `TimeTask` extension methods have no effect if `timing == null`, which means you can turn them all off with a switch in `Startup`:

```c#
public void ConfigureServices(IServiceCollection services)
{
    if (!string.IsNullOrEmpty(this.Configuration["ServerMetrics"]))
        services.AddServerTiming();
```

Then if `timing == null` you won't get errors:
- `using (timing.TimeAction())` becomes `using(null)`, which .NET can optimise as a plain block statement.
- `TimeTask` does still add an additional call to the stack, but this should only be measurable in extreme optimisation scenarios.

This makes it easy to add these metrics to code with the minimum of changes, and ensures the minimum cost when timings are turned off.