### PR TITLE
Added TimeTask method override for Task

### DIFF
--- a/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
@@ -39,6 +39,29 @@ namespace Lib.AspNetCore.ServerTiming
         /// <summary>
         /// Time an async task.
         /// </summary>
+        /// <param name="task">The <see cref="Task"/> to time.</param>
+        /// <param name="serverTiming">The <see cref="IServerTiming"/> to add metric to.</param>
+        /// <param name="metricName">Optional, metric name, if passed will override any caller name.</param>
+        /// <param name="functionName">Optional, populated compile-time with the name of the calling function.</param>
+        /// <param name="filePath">Optional, populated compile-time with the path to the calling file.</param>
+        /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file.</param>
+        /// <returns></returns>
+        public static async Task TimeTask(this IServerTiming serverTiming,
+            Task task,
+            string metricName = null,
+            [CallerMemberName] string functionName = null,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            using (serverTiming.TimeAction(metricName, functionName, filePath, lineNumber))
+            {
+                await task;
+            }
+        }
+
+        /// <summary>
+        /// Time an async task.
+        /// </summary>
         /// <typeparam name="T">Type of the task.</typeparam>
         /// <param name="task">The <see cref="Task"/> to time.</param>
         /// <param name="serverTiming">The <see cref="IServerTiming"/> to add metric to.</param>


### PR DESCRIPTION
The current extension method only accepts generic Task, this adds an override that also accepts a non-generic Task.