### PR TITLE
Refactor middleware to use Options and implement flexible filtering/modification of options

### DIFF
--- a/Demo.AspNetCore.ServerTiming/Controllers/WeatherForecastsController.cs
+++ b/Demo.AspNetCore.ServerTiming/Controllers/WeatherForecastsController.cs
@@ -46,6 +46,7 @@ namespace Demo.AspNetCore.ServerTiming.Controllers
                     weatherForecasts.Add(await GetWeatherForecastAsync(daysFromToday));
                 };
             }
+
             return weatherForecasts;
         }
 

--- a/Demo.AspNetCore.ServerTiming/Controllers/WeatherForecastsController.cs
+++ b/Demo.AspNetCore.ServerTiming/Controllers/WeatherForecastsController.cs
@@ -46,7 +46,6 @@ namespace Demo.AspNetCore.ServerTiming.Controllers
                     weatherForecasts.Add(await GetWeatherForecastAsync(daysFromToday));
                 };
             }
-
             return weatherForecasts;
         }
 

--- a/Demo.AspNetCore.ServerTiming/Startup.cs
+++ b/Demo.AspNetCore.ServerTiming/Startup.cs
@@ -32,7 +32,9 @@ namespace Demo.AspNetCore.ServerTiming
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseServerTiming()
+            app.UseServerTiming(options =>
+            {
+            })
                 .UseRouting()
                 .UseEndpoints(endpoints =>
                 {

--- a/DocFx.AspNetCore.ServerTiming/articles/getting-started.md
+++ b/DocFx.AspNetCore.ServerTiming/articles/getting-started.md
@@ -27,18 +27,22 @@ public class Startup
 }
 ```
 
-There is an option to provide origins that are allowed to see values from timing APIs (which would otherwise be reported as zero due to cross-origin restrictions) while registering the middleware.
+Options can be set when registering the middleware - e.g. to set URLs that are allowed to see values from timing APIs (which would otherwise be reported as zero due to cross-origin restrictions), or to only send timings in a development environment.
 
 ```cs
 public class Startup
 {
     ...
 
-    public void Configure(IApplicationBuilder app)
+    public void Configure(IApplicationBuilder app, IHostEnvironment env)
     {
         ...
 			
-		app.UseServerTiming("https://tpeczek.com", "https://developer.tpeczek.com");
+		app.UseServerTiming(options => {
+            options.AllowedOrigins.Add("https://tpeczek.com");
+            options.AllowedOrigins.Add("https://developer.tpeczek.com");
+            options.RestrictToDevelopment(env)
+        }
 			
 		...
     }

--- a/DocFx.AspNetCore.ServerTiming/articles/processors.md
+++ b/DocFx.AspNetCore.ServerTiming/articles/processors.md
@@ -1,0 +1,70 @@
+﻿# Processors
+
+Processors are run on the collected metrics before they are delivered to the client, and may modify the collection. This allows for flexible filtering of which
+metrics are made available to which callers.
+
+The processors are specified as a collection on the ````options```` in ````UseServerTiming````
+
+```cs
+public class Startup
+{
+    public void Configure(IApplicationBuilder app)
+    {
+        ...
+			
+		app.UseServerTiming(options => {
+            options.Processors.Add( ... );
+        });
+			
+		...
+    }
+}
+```
+
+
+## Built in Processors
+
+A number of built in processors are provided in the ````Lib.AspNetCore.ServerTiming.Processors```` namespace that can:
+
+* Restrict metrics to the development environment
+* Remove the descriptions from metrics when used outside the development environment
+* Restrict metrics to an IP address or IP range
+
+These can be added to the collection manually as shown above, or more conveniently through extension methods on the options collection:
+
+```cs
+public class Startup
+{
+    public void Configure(IApplicationBuilder app)
+    {
+        ...
+			
+		app.UseServerTiming(options => {
+            options.RestrictMetricsToIp("127.0.0.1");
+        });
+			
+		...
+    }
+}
+```
+
+## Custom Processors
+
+You can add custom processors to the collection either by appending an object
+that implements ````IServerTimingProcessor```` to the ````Processors```` 
+collection, or by using the ````AddCustomProcessor```` extension method and supplying a
+lambda function. e.g.
+
+````cs
+	app.UseServerTiming(options => {
+        options.AddCustomProcessor((context, metrics) =>
+        {
+            if (System.DateTime.Now.Hour >=18) metrics.Add(new ServerTimingMetric("Time to stop debugging this and go for a drink!"));
+            return true;
+        });
+    });
+````
+The lambda function (or Process method in a custom processor class) should return true if later processors in the collection
+should be executed, or false if processing should stop and the Metrics collection be returned to the caller.
+
+If processors remove all metrics, no ````ServerTiming```` header is sent.

--- a/DocFx.AspNetCore.ServerTiming/docfx.json
+++ b/DocFx.AspNetCore.ServerTiming/docfx.json
@@ -24,6 +24,7 @@
           "toc.md",
           "index.md",
           "articles/getting-started.md",
+          "articles/processors.md",
           "articles/advanced.md"
         ]
       }

--- a/DocFx.AspNetCore.ServerTiming/toc.md
+++ b/DocFx.AspNetCore.ServerTiming/toc.md
@@ -2,6 +2,8 @@
 
 # [Getting Started](articles/getting-started.md)
 
+# [Processors](articles/processors.md)
+
 # [Advanced](articles/advanced.md)
 
 # [API Reference](api/Lib.AspNetCore.ServerTiming.html)

--- a/Lib.AspNetCore.ServerTiming/Http/Extensions/HttpResponseHeadersExtensions.cs
+++ b/Lib.AspNetCore.ServerTiming/Http/Extensions/HttpResponseHeadersExtensions.cs
@@ -16,7 +16,7 @@ namespace Lib.AspNetCore.ServerTiming.Http.Extensions
         /// <param name="response">The response.</param>
         /// <param name="serverTiming">The Server-Timing header value.</param>
         public static void SetServerTiming(this HttpResponse response, ServerTimingHeaderValue serverTiming)
-        {            
+        {
             response.SetResponseHeader(HeaderNames.ServerTiming, serverTiming?.ToString());
         }
 

--- a/Lib.AspNetCore.ServerTiming/Http/Extensions/HttpResponseHeadersExtensions.cs
+++ b/Lib.AspNetCore.ServerTiming/Http/Extensions/HttpResponseHeadersExtensions.cs
@@ -16,7 +16,7 @@ namespace Lib.AspNetCore.ServerTiming.Http.Extensions
         /// <param name="response">The response.</param>
         /// <param name="serverTiming">The Server-Timing header value.</param>
         public static void SetServerTiming(this HttpResponse response, ServerTimingHeaderValue serverTiming)
-        {
+        {            
             response.SetResponseHeader(HeaderNames.ServerTiming, serverTiming?.ToString());
         }
 

--- a/Lib.AspNetCore.ServerTiming/Http/Headers/ServerTimingMetric.cs
+++ b/Lib.AspNetCore.ServerTiming/Http/Headers/ServerTimingMetric.cs
@@ -70,7 +70,7 @@ namespace Lib.AspNetCore.ServerTiming.Http.Headers
             : this(name, null, description)
         { }
 
-        private ServerTimingMetric(string name, decimal? value, string description)
+        internal ServerTimingMetric(string name, decimal? value, string description)
         {
             if (String.IsNullOrEmpty(name))
             {

--- a/Lib.AspNetCore.ServerTiming/IServerTiming.cs
+++ b/Lib.AspNetCore.ServerTiming/IServerTiming.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Lib.AspNetCore.ServerTiming.Http.Headers;
-using Microsoft.AspNetCore.Http;
 
 namespace Lib.AspNetCore.ServerTiming
 {
@@ -17,7 +16,6 @@ namespace Lib.AspNetCore.ServerTiming
         /// <summary>
         /// Gets the collection of metrics for current request.
         /// </summary>
-        ICollection<ServerTimingMetric> Metrics { get; }
-        
+        ICollection<ServerTimingMetric> Metrics { get; }        
     }
 }

--- a/Lib.AspNetCore.ServerTiming/IServerTiming.cs
+++ b/Lib.AspNetCore.ServerTiming/IServerTiming.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Microsoft.AspNetCore.Http;
 
 namespace Lib.AspNetCore.ServerTiming
 {
@@ -17,5 +18,6 @@ namespace Lib.AspNetCore.ServerTiming
         /// Gets the collection of metrics for current request.
         /// </summary>
         ICollection<ServerTimingMetric> Metrics { get; }
+        
     }
 }

--- a/Lib.AspNetCore.ServerTiming/IServerTimingProcessor.cs
+++ b/Lib.AspNetCore.ServerTiming/IServerTimingProcessor.cs
@@ -1,0 +1,21 @@
+﻿using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+
+namespace Lib.AspNetCore.ServerTiming
+{
+    /// <summary>
+    /// Provides an oportunity to inspect and modify the metrics about to be sent in an HTTP repsonse
+    /// </summary>
+    public interface IServerTimingProcessor
+    {
+        /// <summary>
+        /// Inspects/modifies the set of metrics to be sent in an HTTP Response. If the metrics are
+        /// cleared, no server timing headers are sent
+        /// </summary>
+        /// <param name="context">The context of the current request</param>
+        /// <param name="metrics">The provisional set of metrics to be returned in the response header</param>
+        /// <returns>True if subsequent processors are allowed to run, false if this should be the last processor executed</returns>
+        public bool Process(HttpContext context, List<ServerTimingMetric> metrics);
+    }
+}

--- a/Lib.AspNetCore.ServerTiming/Lib.AspNetCore.ServerTiming.csproj
+++ b/Lib.AspNetCore.ServerTiming/Lib.AspNetCore.ServerTiming.csproj
@@ -23,15 +23,17 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup Condition="('$(TargetFramework)' == 'netcoreapp2.1') Or ('$(TargetFramework)' == 'net461')">
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="[2.1.0,3.0.0)" />
   </ItemGroup>
   <ItemGroup Condition="('$(TargetFramework)' != 'netcoreapp2.1') And ('$(TargetFramework)' != 'net461')">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="0.1.66" PrivateAssets="All"/>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="0.1.66" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/Lib.AspNetCore.ServerTiming/Processors/CustomProcessor.cs
+++ b/Lib.AspNetCore.ServerTiming/Processors/CustomProcessor.cs
@@ -1,0 +1,27 @@
+﻿using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+
+namespace Lib.AspNetCore.ServerTiming.Processors
+{
+    /// <summary>
+    /// Implement a custom processor using a lambda
+    /// </summary>
+    public class CustomProcessor : IServerTimingProcessor
+    {
+        private readonly Func<HttpContext, List<ServerTimingMetric>, bool> _process;
+
+        /// <summary>
+        /// Create a custom processor
+        /// </summary>
+        /// <param name="process">Lambda to execute processing</param>
+        public CustomProcessor(Func<HttpContext, List<ServerTimingMetric>, bool> process)
+        {
+            _process = process;
+        }
+
+        ///<inheritdoc/>
+        public bool Process(HttpContext context, List<ServerTimingMetric> metrics) => _process(context, metrics);
+    }
+}

--- a/Lib.AspNetCore.ServerTiming/Processors/DevelopmentEnvironmentBasedProcessor.cs
+++ b/Lib.AspNetCore.ServerTiming/Processors/DevelopmentEnvironmentBasedProcessor.cs
@@ -1,0 +1,40 @@
+﻿using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+
+namespace Lib.AspNetCore.ServerTiming.Processors
+{
+    /// <summary>
+    /// Base class for processors whose behaviour changes in the development environment
+    /// </summary>
+    public abstract class DevelopmentEnvironmentBasedProcessor : IServerTimingProcessor
+    {
+        /// <summary>
+        /// True if running in the development environment
+        /// </summary>
+        protected readonly bool IsDevelopment = false;
+
+
+#if !NETCOREAPP2_1 && !NET461
+        /// <summary>
+        /// Create an DevelopmentEnvironmentBasedProcessor
+        /// </summary>
+        /// <param name="hostEnvironment">The host environment used to determine if this is a development environment</param>
+        public DevelopmentEnvironmentBasedProcessor(Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment)
+        {
+            IsDevelopment = hostEnvironment.EnvironmentName == Microsoft.Extensions.Hosting.Environments.Development;
+        }
+#else
+        /// <summary>
+        /// Create an AllowInDevelopmentEnvironmentProcessor
+        /// </summary>
+        /// <param name="hostingEnvironment">The hosting environment used to determine if this is a development environment</param>
+        public DevelopmentEnvironmentBasedProcessor(Microsoft.AspNetCore.Hosting.IHostingEnvironment hostingEnvironment)
+        {
+            IsDevelopment = Microsoft.AspNetCore.Hosting.HostingEnvironmentExtensions.IsDevelopment(hostingEnvironment);
+        }
+#endif
+        /// <inheritdoc/>
+        public abstract bool Process(HttpContext context, List<ServerTimingMetric> metrics);
+    }
+}

--- a/Lib.AspNetCore.ServerTiming/Processors/IpProcessor.cs
+++ b/Lib.AspNetCore.ServerTiming/Processors/IpProcessor.cs
@@ -1,0 +1,88 @@
+﻿using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace Lib.AspNetCore.ServerTiming.Processors
+{
+    /// <summary>
+    /// Limit when server timing responses are sent based on IP address ranges
+    /// </summary>
+    public class IpProcessor : IServerTimingProcessor
+    {
+        private readonly byte[] _from;
+        private readonly byte[] _to;
+        
+        /// <summary>
+        /// Creates a processor that only permits acess to the given range
+        /// </summary>
+        /// <param name="from">Lower address in range</param>
+        /// <param name="to">Upper address in range</param>
+        public IpProcessor(IPAddress from, IPAddress to)
+        {
+            _from = from.MapToIPv6().GetAddressBytes();
+            _to = to.MapToIPv6().GetAddressBytes();
+        }
+
+        /// <inheritdoc/>
+        public bool Process(HttpContext context, List<ServerTimingMetric> metrics)
+        {
+            bool inRange = InRange(context.Connection.RemoteIpAddress.MapToIPv6().GetAddressBytes());
+
+            if (!inRange)
+            {
+                metrics.Clear();
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if the supplied ip address bytes are in the range
+        /// </summary>
+        /// <param name="ip"></param>
+        /// <returns></returns>
+        private bool InRange(byte[] ip) => IsGreaterThanOrEqualTo(ip,_from) || IsLessThanOrEqualTo(ip,_to);
+
+        /// <summary>
+        /// Compares two equal length byte arrays and return true if b1 is less than nor equal to b2
+        /// </summary>
+        /// <param name="b1"></param>
+        /// <param name="b2"></param>
+        /// <returns></returns>
+        private bool IsGreaterThanOrEqualTo(byte[] b1, byte[] b2)
+        {
+            int i = 0;
+            while (i<b1.Length)
+            {                
+                int c = b1[i].CompareTo(b2[i]);
+                if (c == 1) return true;
+                if (c == -1) return false;
+                i++; 
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Compares two equal length byte arrays and return true if b1 is less than nor equal to b2
+        /// </summary>
+        /// <param name="b1"></param>
+        /// <param name="b2"></param>
+        /// <returns></returns>
+        private bool IsLessThanOrEqualTo(byte[] b1, byte[] b2)
+        {
+        int i = 0;
+        while (i < b1.Length)
+        {
+            int c = b1[i].CompareTo(b2[i]);
+            if (c == 1) return false;
+            if (c == -1) return true;
+            i++;
+        }
+        return true;
+    }
+
+}
+}

--- a/Lib.AspNetCore.ServerTiming/Processors/RemoveAllMetricsProcessor.cs
+++ b/Lib.AspNetCore.ServerTiming/Processors/RemoveAllMetricsProcessor.cs
@@ -1,0 +1,19 @@
+﻿using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+
+namespace Lib.AspNetCore.ServerTiming.Processors
+{
+    /// <summary>
+    /// A processor to clear all metrics in the response
+    /// </summary>
+    public class RemoveAllMetricsProcessor : IServerTimingProcessor
+    {
+        /// <inheritdoc/>
+        public bool Process(HttpContext context, List<ServerTimingMetric> metrics)
+        {
+            metrics.Clear();
+            return true;
+        }
+    }
+}

--- a/Lib.AspNetCore.ServerTiming/Processors/RestrictDescriptionsToDevelopmentProcessor.cs
+++ b/Lib.AspNetCore.ServerTiming/Processors/RestrictDescriptionsToDevelopmentProcessor.cs
@@ -1,0 +1,49 @@
+﻿using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Lib.AspNetCore.ServerTiming.Processors
+{
+    /// <summary>
+    /// A processor which will remove the descriptions from all metrics unless in the development environment
+    /// </summary>
+    public class RestrictDescriptionsToDevelopmentProcessor : DevelopmentEnvironmentBasedProcessor
+    {
+#if !NETCOREAPP2_1 && !NET461
+        /// <summary>
+        /// Create an RestrictDescriptionsToDevelopmentProcessor
+        /// </summary>
+        /// <param name="hostEnvironment">The host environment used to determine if this is a development environment</param>
+        public RestrictDescriptionsToDevelopmentProcessor(Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment):base(hostEnvironment)
+        {
+        }
+#else
+        /// <summary>
+        /// Create an RestrictDescriptionsToDevelopmentProcessor
+        /// </summary>
+        /// <param name="hostingEnvironment">The hosting environment used to determine if this is a development environment</param>
+        public RestrictDescriptionsToDevelopmentProcessor(Microsoft.AspNetCore.Hosting.IHostingEnvironment hostingEnvironment) : base(hostingEnvironment)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Force no further middleware to run if in development environment
+        /// </summary>
+        /// <param name="context">Not used</param>
+        /// <param name="metrics">Not used</param>
+        /// <returns></returns>
+        public override bool Process(HttpContext context, List<ServerTimingMetric> metrics)
+        {
+            if (!IsDevelopment)
+            {
+                List<ServerTimingMetric> newMetrics = metrics.Select(m => new ServerTimingMetric(m.Name,m.Value,null)).ToList();
+                metrics.Clear();
+                metrics.AddRange(newMetrics);
+            }
+            //Allow next processor to run
+            return true;
+        }
+    }
+}

--- a/Lib.AspNetCore.ServerTiming/Processors/RestrictMetricsToDevelopmentProcessor.cs
+++ b/Lib.AspNetCore.ServerTiming/Processors/RestrictMetricsToDevelopmentProcessor.cs
@@ -1,0 +1,47 @@
+﻿using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+
+namespace Lib.AspNetCore.ServerTiming.Processors
+{
+    /// <summary>
+    /// A processor which will allow all headers to be sent in the development environment,
+    /// and will not run any futher processors
+    /// </summary>
+    public class RestrictMetricsToDevelopmentProcessor : DevelopmentEnvironmentBasedProcessor
+    {
+#if !NETCOREAPP2_1 && !NET461
+        /// <summary>
+        /// Create an RestrictMetricsToDevelopmentProcessor
+        /// </summary>
+        /// <param name="hostEnvironment">The host environment used to determine if this is a development environment</param>
+        public RestrictMetricsToDevelopmentProcessor(Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment):base(hostEnvironment)
+        {
+        }
+#else
+        /// <summary>
+        /// Create an RestrictMetricsToDevelopmentProcessor
+        /// </summary>
+        /// <param name="hostingEnvironment">The hosting environment used to determine if this is a development environment</param>
+        public RestrictMetricsToDevelopmentProcessor(Microsoft.AspNetCore.Hosting.IHostingEnvironment hostingEnvironment) : base(hostingEnvironment)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Force no further middleware to run if in development environment
+        /// </summary>
+        /// <param name="context">Not used</param>
+        /// <param name="metrics">Not used</param>
+        /// <returns></returns>
+        public override bool Process(HttpContext context, List<ServerTimingMetric> metrics)
+        {
+            if (!IsDevelopment)
+            {
+                metrics.Clear();
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Lib.AspNetCore.ServerTiming/ServerTimingMiddlewareExtensions.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingMiddlewareExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(app));
             }
 
-            return app.UseMiddleware<ServerTimingMiddleware>();
+            return UseServerTiming(app, options=> { });
         }
 
         /// <summary>
@@ -32,6 +32,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The <see cref="IApplicationBuilder"/> passed to Configure method.</param>
         /// <param name="timingAllowOrigins">The collection of origins that are allowed to see values from timing APIs.</param>
         /// <returns>The original app parameter</returns>
+        [Obsolete("Use a version of this method that takes a lambda function to intialise options")]
         public static IApplicationBuilder UseServerTiming(this IApplicationBuilder app, ICollection<string> timingAllowOrigins)
         {
             if (app is null)
@@ -39,7 +40,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(app));
             }
 
-            return app.UseMiddleware<ServerTimingMiddleware>(timingAllowOrigins);
+            return UseServerTiming(app, options => options.AllowedOrigins.AddRange(timingAllowOrigins));
         }
 
         /// <summary>
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The <see cref="IApplicationBuilder"/> passed to Configure method.</param>
         /// <param name="timingAllowOrigins">The origins that are allowed to see values from timing APIs.</param>
         /// <returns>The original app parameter</returns>
+        [Obsolete("Use a version of this method that takes a lambda function to intialise options")]
         public static IApplicationBuilder UseServerTiming(this IApplicationBuilder app, params string[] timingAllowOrigins)
         {
             if (app is null)
@@ -55,7 +57,26 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(app));
             }
 
-            return app.UseMiddleware<ServerTimingMiddleware>(new TimingAllowOriginHeaderValue(timingAllowOrigins));
+            return UseServerTiming(app,options => options.AllowedOrigins.AddRange(timingAllowOrigins));
+        }
+
+
+        /// <summary>
+        /// Adds a <see cref="ServerTimingMiddleware"/> to application pipeline.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> passed to Configure method.</param>
+        /// <param name="setOptionsCallback">A lambda to set the configuration options for server timing</param>        
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseServerTiming(this IApplicationBuilder app, Action<ServerTimingOptions> setOptionsCallback)
+        {
+            if (app is null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+            var options = new ServerTimingOptions();
+            setOptionsCallback?.Invoke(options);
+
+            return app.UseMiddleware<ServerTimingMiddleware>(options);
         }
         #endregion
     }

--- a/Lib.AspNetCore.ServerTiming/ServerTimingOptions.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingOptions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Lib.AspNetCore.ServerTiming
+{
+    /// <summary>
+    /// Configuration options for server timing
+    /// </summary>
+    public class ServerTimingOptions
+    {
+        /// <summary>
+        /// The collection of origins that are allowed to see values from timing APIs.
+        /// </summary>
+        public List<string> AllowedOrigins { get; } = new List<string>();
+
+        /// <summary>
+        /// The collection of processors that are executed before any header is sent
+        /// </summary>
+        public List<IServerTimingProcessor> Processors { get; } = new List<IServerTimingProcessor>();
+    }
+}

--- a/Lib.AspNetCore.ServerTiming/ServerTimingOptionsExtensions.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingOptionsExtensions.cs
@@ -1,0 +1,106 @@
+﻿using Lib.AspNetCore.ServerTiming.Http.Headers;
+using Lib.AspNetCore.ServerTiming.Processors;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Lib.AspNetCore.ServerTiming
+{
+    /// <summary>
+    /// Methods to provide shortcuts for setting the server timing options
+    /// </summary>
+    public static class ServerTimingOptionsExtensions
+    {
+#if !NETCOREAPP2_1 && !NET461
+        /// <summary>
+        /// Configure the processors collection to only send headers in the development environment
+        /// </summary>
+        /// <param name="options">The options to modify</param>
+        /// <param name="hostEnvironment">The host application's environment</param>
+        public static void RestrictMetricsToDevelopment(this ServerTimingOptions options, 
+            Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment)
+        {
+            options.Processors.Add(new RestrictMetricsToDevelopmentProcessor(hostEnvironment));
+        }
+
+        /// <summary>
+        /// Configure the processors collection to only send headers in the development environment
+        /// </summary>
+        /// <param name="options">The options to modify</param>
+        /// <param name="hostEnvironment">The host application's environment</param>
+        public static void RestrictDescriptionsToDevelopment(this ServerTimingOptions options, 
+            Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment)
+        {
+            options.Processors.Add(new RestrictDescriptionsToDevelopmentProcessor(hostEnvironment));
+        }
+#else
+        /// <summary>
+        /// Configure the processors collection to only send headers in the development environment
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="hostingEnvironment"></param>
+        public static void RestrictMetricsToDevelopment(this ServerTimingOptions options, 
+            Microsoft.AspNetCore.Hosting.IHostingEnvironment hostingEnvironment)
+        {
+            options.Processors.Add(new RestrictMetricsToDevelopmentProcessor(hostingEnvironment));
+        }
+
+        /// <summary>
+        /// Configure the processors collection to only send headers in the development environment
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="hostingEnvironment"></param>
+        public static void RemoveDescriptionsOutsideDevelopment(this ServerTimingOptions options, 
+            Microsoft.AspNetCore.Hosting.IHostingEnvironment hostingEnvironment)
+        {
+            options.Processors.Add(new RestrictDescriptionsToDevelopmentProcessor(hostingEnvironment));
+        }
+#endif
+
+        /// <summary>
+        /// Configure the processors collection to only send headers to a specific IP
+        /// </summary>
+        /// <param name="options">Options to update</param>
+        /// <param name="ip">IP Address to permit</param>
+        public static void RestrictMetricsToIp(this ServerTimingOptions options, IPAddress ip)
+            => RestrictMetricsToIpRange(options, ip, ip);
+
+        /// <summary>
+        /// Configure the processors collection to only send headers to a specific IP
+        /// </summary>
+        /// <param name="options">Options to update</param>
+        /// <param name="ip">IP Address to permit</param>
+        public static void RestrictMetricsToIp(this ServerTimingOptions options, string ip)
+            => RestrictMetricsToIpRange(options, ip, ip);
+
+
+        /// <summary>
+        /// Configure the processors collection to only send headers to a specific IP range
+        /// </summary>
+        /// <param name="options">Options to update</param>
+        /// <param name="from">Minimum IP Address to permit</param>
+        /// <param name="to">Maximum IP Address to permit</param>
+        public static void RestrictMetricsToIpRange(this ServerTimingOptions options, string from, string to)
+            => options.Processors.Add(new IpProcessor(IPAddress.Parse(from), IPAddress.Parse(to)));
+
+        /// <summary>
+        /// Configure the processors collection to only send headers to a specific IP range
+        /// </summary>
+        /// <param name="options">Options to update</param>
+        /// <param name="from">Minimum IP Address to permit</param>
+        /// <param name="to">Maximum IP Address to permit</param>
+        public static void RestrictMetricsToIpRange(this ServerTimingOptions options, IPAddress from, IPAddress to)
+            => options.Processors.Add(new IpProcessor(from, to));
+
+        /// <summary>
+        /// Add a custom processor to filter / modify metrics
+        /// </summary>
+        /// <param name="options">Options to update</param>
+        /// <param name="process">Processing lambda. This may modify the metrics list it is passed, and should return true if
+        /// further processors are allowed to run or false if they should be suppressed.</param>
+        public static void AddCustomProcessor(this ServerTimingOptions options, Func<HttpContext, List<ServerTimingMetric>, bool> process)
+            => options.Processors.Add(new CustomProcessor(process));
+
+    }
+}

--- a/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
@@ -84,7 +84,7 @@ namespace Lib.AspNetCore.ServerTiming
         }
 
         /// <summary>
-        /// Add a metric to the timing, if present.
+        /// Add a timed metric to the timing, if present.
         /// </summary>
         /// <param name="serverTiming">The <see cref="IServerTiming"/> to add metric to.</param>
         /// <param name="duration">The duration to log in ms.</param>
@@ -92,7 +92,7 @@ namespace Lib.AspNetCore.ServerTiming
         /// <param name="functionName">Optional, populated compile-time with the name of the calling function</param>
         /// <param name="filePath">Optional, populated compile-time with the path to the calling file</param>
         /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file</param>
-        public static void AddMetric(this IServerTiming serverTiming, decimal duration,
+        public static ServerTimingMetric? AddMetric(this IServerTiming serverTiming, decimal duration,
             string metricName = null,
             [CallerMemberName] string functionName = null,
             [CallerFilePath] string filePath = null,
@@ -100,13 +100,43 @@ namespace Lib.AspNetCore.ServerTiming
         {
             if (serverTiming is null)
             {
-                return;
+                return null;
             }
 
             ServerTimingMetric metric = new ServerTimingMetric(metricName ?? FormatCallerName(functionName, filePath, lineNumber), duration);
 
             serverTiming.Metrics.Add(metric);
+            return metric;
         }
+
+        /// <summary>
+        /// Add an untimed metric to the timing, if present.
+        /// </summary>
+        /// <param name="serverTiming">The <see cref="IServerTiming"/> to add metric to.</param>
+        /// <param name="metricName">The name of the metric to log.</param>
+        /// <param name="description">The description of the metric</param>
+        /// <param name="functionName">Optional, populated compile-time with the name of the calling function</param>
+        /// <param name="filePath">Optional, populated compile-time with the path to the calling file</param>
+        /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file</param>
+        public static ServerTimingMetric? AddMetric(this IServerTiming serverTiming,
+            string metricName = null,
+            string description = null,
+            [CallerMemberName] string functionName = null,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            if (serverTiming is null)
+            {
+                return null;
+            }
+
+            ServerTimingMetric metric = new ServerTimingMetric(metricName ?? FormatCallerName(functionName, filePath, lineNumber), description);
+
+            serverTiming.Metrics.Add(metric);
+            return metric;
+        }
+
+
 
         internal static void SetServerTimingDeliveryMode(this IServerTiming serverTiming, ServerTimigDeliveryMode deliveryMode)
         {

--- a/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
@@ -98,6 +98,11 @@ namespace Lib.AspNetCore.ServerTiming
             [CallerFilePath] string filePath = null,
             [CallerLineNumber] int lineNumber = 0)
         {
+            if (serverTiming is null)
+            {
+                return;
+            }
+
             ServerTimingMetric metric = new ServerTimingMetric(metricName ?? FormatCallerName(functionName, filePath, lineNumber), duration);
 
             serverTiming.Metrics.Add(metric);
@@ -118,7 +123,12 @@ namespace Lib.AspNetCore.ServerTiming
             [CallerMemberName] string functionName = null,
             [CallerFilePath] string filePath = null,
             [CallerLineNumber] int lineNumber = 0)
-        {        
+        {
+            if (serverTiming is null)
+            {
+                return;
+            }
+
             ServerTimingMetric metric = new ServerTimingMetric(metricName ?? FormatCallerName(functionName, filePath, lineNumber), description);
 
             serverTiming.Metrics.Add(metric);

--- a/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
+++ b/Lib.AspNetCore.ServerTiming/ServerTimingUtility.cs
@@ -92,21 +92,15 @@ namespace Lib.AspNetCore.ServerTiming
         /// <param name="functionName">Optional, populated compile-time with the name of the calling function</param>
         /// <param name="filePath">Optional, populated compile-time with the path to the calling file</param>
         /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file</param>
-        public static ServerTimingMetric? AddMetric(this IServerTiming serverTiming, decimal duration,
+        public static void AddMetric(this IServerTiming serverTiming, decimal duration,
             string metricName = null,
             [CallerMemberName] string functionName = null,
             [CallerFilePath] string filePath = null,
             [CallerLineNumber] int lineNumber = 0)
         {
-            if (serverTiming is null)
-            {
-                return null;
-            }
-
             ServerTimingMetric metric = new ServerTimingMetric(metricName ?? FormatCallerName(functionName, filePath, lineNumber), duration);
 
             serverTiming.Metrics.Add(metric);
-            return metric;
         }
 
         /// <summary>
@@ -118,22 +112,16 @@ namespace Lib.AspNetCore.ServerTiming
         /// <param name="functionName">Optional, populated compile-time with the name of the calling function</param>
         /// <param name="filePath">Optional, populated compile-time with the path to the calling file</param>
         /// <param name="lineNumber">Optional, populated compile-time with line number in the calling file</param>
-        public static ServerTimingMetric? AddMetric(this IServerTiming serverTiming,
+        public static void AddMetric(this IServerTiming serverTiming,
             string metricName = null,
             string description = null,
             [CallerMemberName] string functionName = null,
             [CallerFilePath] string filePath = null,
             [CallerLineNumber] int lineNumber = 0)
-        {
-            if (serverTiming is null)
-            {
-                return null;
-            }
-
+        {        
             ServerTimingMetric metric = new ServerTimingMetric(metricName ?? FormatCallerName(functionName, filePath, lineNumber), description);
 
             serverTiming.Metrics.Add(metric);
-            return metric;
         }
 
 


### PR DESCRIPTION
This pull request addresses issue #16 by allowing the user to register a list of "processors" which can process the metrics collection before it is sent to the caller. To support this I've added a new overload for UseServerTiming that uses a lambda to provide options as is the standard practice in ASP.Net core middleware.

I've implemented processors to:

* Remove metrics if not in development environment
* Remove descriptions from metrics if not in development environment
* Only send metrics to an IP address or IP address range
* Remove all metrics
* Implement custom logic using a user-provided lambda function

I've also added a 2nd overload to AddMetric that doesn't take a timing to make it easier to add untimed metrics.

There should be no breaking changes.